### PR TITLE
Updated package for Logrus library to the right one

### DIFF
--- a/json_logger.go
+++ b/json_logger.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"os"
 	"path/filepath"
 	"runtime"


### PR DESCRIPTION
Compiling the existing library I receive this error:

`
github.com/zooplus/golang-logging imports
	github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.9.0: parsing go.mod:
	module declares its path as: github.com/sirupsen/logrus
	        but was required as: github.com/Sirupsen/logrus
`

Changing to the lowercase should fix the problem.